### PR TITLE
[Backend] Sign up

### DIFF
--- a/backend/prisma/migrations/20260330135628_email_unverified_not_unique/migration.sql
+++ b/backend/prisma/migrations/20260330135628_email_unverified_not_unique/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "User_email_unverified_key";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,7 +12,7 @@ model User {
   id               String   @id @default(uuid(7))
   username         String   @unique
   email            String?  @unique
-  email_unverified String?  @unique
+  email_unverified String?
   password         String
   desc             String?  @db.VarChar(200)
   avatar           String?

--- a/backend/src/api/api.module.ts
+++ b/backend/src/api/api.module.ts
@@ -7,6 +7,8 @@ import { UserController } from './user/user.controller';
 import { UserService } from './user/user.service';
 import { RelController } from './relationships/rel.controller';
 import { RelService } from './relationships/rel.service';
+import { AuthController } from './auth/auth.controller';
+import { AuthService } from './auth/auth.service';
 
 @Module({
   controllers: [
@@ -14,7 +16,14 @@ import { RelService } from './relationships/rel.service';
     SendMailController,
     UserController,
     RelController,
+    AuthController,
   ],
-  providers: [HelloService, SendMailService, UserService, RelService],
+  providers: [
+    HelloService,
+    SendMailService,
+    UserService,
+    RelService,
+    AuthService,
+  ],
 })
 export class ApiModule {}

--- a/backend/src/api/auth/auth.controller.ts
+++ b/backend/src/api/auth/auth.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { UserService } from '../user/user.service';
+import { CreateUserDto } from '../user/dto/create-user.dto';
+
+@Controller('/api/auth')
+export class AuthController {
+  constructor(private readonly userService: UserService) {}
+
+  @Post('signup')
+  async addUser(@Body() createUserDto: CreateUserDto) {
+    return await this.userService.addUser(createUserDto);
+  }
+}

--- a/backend/src/api/auth/auth.service.ts
+++ b/backend/src/api/auth/auth.service.ts
@@ -1,0 +1,10 @@
+import { CreateUserDto } from '../user/dto/create-user.dto';
+import { UserService } from '../user/user.service';
+
+export class AuthService {
+  constructor(private readonly userService: UserService) {}
+
+  async signup(createUserDto: CreateUserDto) {
+    return await this.userService.addUser(createUserDto);
+  }
+}

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -9,7 +9,6 @@ import {
   Get,
 } from '@nestjs/common';
 import { UserService } from './user.service';
-import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUsernameDto } from './dto/update-username.dto';
 import { UpdateDescDto } from './dto/update-desc.dto';
 import { UpdateAvatarDto } from './dto/update-avatar.dto';
@@ -20,10 +19,7 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   // ADD / REMOVE
-  @Post()
-  async addUser(@Body() createUserDto: CreateUserDto) {
-    return await this.userService.addUser(createUserDto);
-  }
+  // Add user moved to auth controller
 
   @Delete(':userId')
   async removeUser(@Param('userId', ParseUUIDPipe) userId: string) {

--- a/backend/src/api/user/user.service.ts
+++ b/backend/src/api/user/user.service.ts
@@ -65,7 +65,11 @@ export class UserService {
       omit: { password: true },
     });
     await this.prisma.user.deleteMany({
+      where: { email: null, email_unverified: verified.email },
+    });
+    await this.prisma.user.updateMany({
       where: { email_unverified: verified.email },
+      data: { email_unverified: null },
     });
     return verified;
   }

--- a/backend/src/api/user/user.service.ts
+++ b/backend/src/api/user/user.service.ts
@@ -59,11 +59,15 @@ export class UserService {
     if (!found.email_unverified) {
       throw new BadRequestException(ErrorMessages.NO_EMAIL);
     }
-    return await this.prisma.user.update({
+    const verified = await this.prisma.user.update({
       where: { id: userId },
       data: { email: found.email_unverified, email_unverified: null },
       omit: { password: true },
     });
+    await this.prisma.user.deleteMany({
+      where: { email_unverified: verified.email },
+    });
+    return verified;
   }
 
   async updateDesc(userId: string, newDesc: string | undefined) {

--- a/backend/src/api/user/user.service.ts
+++ b/backend/src/api/user/user.service.ts
@@ -141,12 +141,7 @@ export class UserService {
 
   async findByEmailAddress(toFind: string) {
     return await this.prisma.user.findFirst({
-      where: {
-        OR: [
-          { email: { equals: toFind, mode: 'insensitive' } },
-          { email_unverified: { equals: toFind, mode: 'insensitive' } },
-        ],
-      },
+      where: { email: { equals: toFind, mode: 'insensitive' } },
       omit: { password: true },
     });
   }


### PR DESCRIPTION
# Add User

All of the verification required by this issue was already implemented by the `addUser` method in the user service. The main change was to create the `/api/auth` endpoint and to create a `signup` method that calls `addUser` from the user service. `addUser` is no longer available via the `user` endpoint.

The CreateUserDto has been left in the user dto directory as although we are calling from the auth service, it is still a user table method and it makes sense to leave it grouped with the other user table dto classes.



# Unverified Email

As we only compare against the `email` field not the `email_unverified` field, this implies that there can be other unverified accounts with the same email. This means that a *User A* cannot block *User B* from creating an account by signing up with *User B*'s email address but not verifying it. To enable this, the `email_unverified`  field in the prisma model is no longer marked as unique. The `verifyEmail` method has been modified to deal with any duplicate rows using the same email address after it has been verified by it's owner:
- If the user has another validated email address, email_unverified is set to null
- If they are unverified, the row is removed

 It will be further modfied later by issue #49.



# User Login

As user login is not yet implemented we're not able to automatically log the user in after sign up. This has been added as a sub-issue of issue #46