### PR TITLE
[Backend] Use Adminer For Prod DB Access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,6 @@ env-file:
 		echo "DEV_URL=http://$(HOST_IP):3000" >> $(ENV_FILE); \
 		echo "PROD_URL=https://$(HOST_IP):8080" >> $(ENV_FILE); \
 		echo "JWT_SECRET=$$(openssl rand -hex 32)" >> $(ENV_FILE); \
-		echo "DB_ACCESS_USER=db_admin" >> $(ENV_FILE); \
-		echo "DB_ACCESS_PASSWORD=$$(openssl rand -hex 32)" >> $(ENV_FILE); \
 		echo "GUEST_PASSWORD=$$(openssl rand -hex 32)" >> $(ENV_FILE); \
 		cat $(VARIABLE_IMPORTS) >> $(ENV_FILE); \
 		echo "Generated .env file";\

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ been tested on Linux, so we do not guarantee it would work on another system.
 - A development build also allows you to manually access the DB at
   `http://localhost:5555`.
 
+- For the prod build, the project includes an Adminer container to inspect the
+  database. This is only accessible from the host machine and can be found at:
+  http://localhost:54245. The login data can be found the containers/.env:
+  - System: PostgreSQL
+  - Server: db
+  - Username: $POSTGRES_USER
+  - Password: $POSTGRES_PASSWORD
+  - Database: $POSTGRES_DB
+
 - No matter the version, instead of `locahost` you can use your IP as the
   domain name. It allows other machines on the same network to access the website
   at `https://127.0.0.1:8080` for example. To find your IP, run

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ been tested on Linux, so we do not guarantee it would work on another system.
 
 - For the prod build, the project includes an Adminer container to inspect the
   database. This is only accessible from the host machine and can be found at:
-  http://localhost:54245. The login data can be found the containers/.env:
-  - System: PostgreSQL
-  - Server: db
-  - Username: $POSTGRES_USER
-  - Password: $POSTGRES_PASSWORD
-  - Database: $POSTGRES_DB
+  `http://localhost:54245`. The login data can be found the `containers/.env`:
+  - System: `PostgreSQL`
+  - Server: `db`
+  - Username: `$POSTGRES_USER`
+  - Password: `$POSTGRES_PASSWORD`
+  - Database: `$POSTGRES_DB`
 
 - No matter the version, instead of `locahost` you can use your IP as the
   domain name. It allows other machines on the same network to access the website

--- a/containers/app/prod_entrypoint.sh
+++ b/containers/app/prod_entrypoint.sh
@@ -3,7 +3,6 @@
 set -e
 
 cd /app
-npx prisma studio --port 5555 --browser none &
 npx prisma migrate deploy
 
 exec node /app/dist/main.js

--- a/containers/docker-compose.backend_dev.yml
+++ b/containers/docker-compose.backend_dev.yml
@@ -5,7 +5,6 @@ services:
     ports:
       - "3000:3000"
       - "5555:5555"
-      - "50006:50006"
     environment:
       NODE_ENV: development
     volumes:

--- a/containers/docker-compose.frontend_dev.yml
+++ b/containers/docker-compose.frontend_dev.yml
@@ -6,7 +6,6 @@ services:
       - "3000:3000"
       - "5173:5173"
       - "5555:5555"
-      - "50006:50006"
     environment:
       NODE_ENV: development
     volumes:

--- a/containers/docker-compose.prod.yml
+++ b/containers/docker-compose.prod.yml
@@ -14,13 +14,9 @@ services:
       context: ..
       dockerfile: containers/nginx/Dockerfile
     container_name: nginx
-    environment:
-      DB_USER: ${DB_ACCESS_USER}
-      DB_PASS: ${DB_ACCESS_PASSWORD}
     restart: unless-stopped
     ports:
       - '8080:8080'
-      - '5555:5555'
     depends_on:
       - app
     networks:
@@ -29,6 +25,21 @@ services:
       - ./nginx/certs:/etc/nginx/certs:ro
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf.template:ro
 
+  adminer:
+    image: adminer:standalone
+    container_name: adminer
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:54245:8080"
+    networks:
+      - adminer
+
+  db:
+    networks:
+      - adminer
+
 networks:
   app-net:
+    driver: bridge
+  adminer:
     driver: bridge

--- a/containers/nginx/entrypoint.sh
+++ b/containers/nginx/entrypoint.sh
@@ -6,6 +6,4 @@ export DOCKER_IP=$(ip route | awk '/default/ { print $3 }')
 
 envsubst '${DOCKER_IP}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
-htpasswd -cb /etc/nginx/db_password $DB_USER $DB_PASS
-
 exec /docker-entrypoint.sh nginx -g 'daemon off;'

--- a/containers/nginx/nginx.conf
+++ b/containers/nginx/nginx.conf
@@ -23,20 +23,4 @@ http {
         proxy_set_header Connection "upgrade";
     }
   }
-
-server {
-    listen 5555 ssl;
-    ssl_certificate     /etc/nginx/certs/cert.pem;
-    ssl_certificate_key /etc/nginx/certs/key.pem;
-
-    allow ${DOCKER_IP};
-    deny all;
-
-    auth_basic "Database Admin";
-    auth_basic_user_file /etc/nginx/db_password;
-
-    location / {
-        proxy_pass http://app:5555;
-    }
-  }
 }


### PR DESCRIPTION
Adminer now works and is only accessible from the host machine.

The password for prisma studio has been removed from the Makefile. The entrypoint for nginx no longer produces the password hash and nding.conf now only has the app container endpoint.

Anew docker network has been created so that adminer may communicate with the db and nothing else.

Port 50006 has been removed from front and backend dev builds. This was for ssh with the dev containers built in my ghcr.io repo.